### PR TITLE
BAU: Running integration tests as part of gradle test task and fixing integration test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,11 @@ sourceSets {
     }
 }
 
+task integrationTest(type: Test) {
+    testClassesDir = sourceSets.integrationTest.output.classesDir
+    classpath += sourceSets.integrationTest.runtimeClasspath
+}
+
 distributions {
     main {
         contents {

--- a/src/integration-test/java/uk/gov/ida/verifylocalmatchingserviceexample/rules/TestDatabaseRule.java
+++ b/src/integration-test/java/uk/gov/ida/verifylocalmatchingserviceexample/rules/TestDatabaseRule.java
@@ -37,8 +37,11 @@ public class TestDatabaseRule extends ExternalResource {
 
     private void setUpDatabase() {
         Flyway flyway = new Flyway();
-        flyway.setDataSource(this.appRule.getConfiguration().getDataSourceFactory().getUrl(), this.appRule.getConfiguration().getDataSourceFactory().getUser(), this.appRule.getConfiguration().getDataSourceFactory().getPassword());
-        flyway.setLocations("classpath:db.migration.common", this.appRule.getConfiguration().getDatabaseMigrationSetup().getDatabaseEngine().getEngineSpecificMigrationsLocation());
+        flyway.setDataSource(this.appRule.getConfiguration().getDataSourceFactory().getUrl(),
+                this.appRule.getConfiguration().getDataSourceFactory().getUser(),
+                this.appRule.getConfiguration().getDataSourceFactory().getPassword());
+        flyway.setLocations("classpath:db.migration.common",
+                this.appRule.getConfiguration().getDatabaseMigrationSetup().getDatabaseEngine().getEngineSpecificMigrationsLocation());
         flyway.clean();
         flyway.migrate();
     }

--- a/src/integration-test/resources/verify-local-matching-service-test.yml
+++ b/src/integration-test/resources/verify-local-matching-service-test.yml
@@ -26,4 +26,4 @@ database:
   url: jdbc:h2:mem:test
 
 managedDatabase:
-  databaseEngine: sqlite
+  databaseEngine: postgresql


### PR DESCRIPTION
Integration tests were failing since H2 didn't like sqlite syntax
so I have changed it to use postgres migration script.

Authors: @SKeerthana