### PR TITLE
TT-1757: Make pre-commit match jenkins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ build/
 *.iml
 *.ipr
 *.iws
+*.log
 *.swp

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -13,13 +13,6 @@ pushd ../verify-matching-service-test-tool
     unzip verify-matching-service-test-tool-*.zip
     cd verify-matching-service-test-tool-*
 
-    rm -rf examples
-    cp -r ../../verify-local-matching-service-example/examples .
-
-cat <<EOF > verify-matching-service-test-tool.yml
-localMatchingService:
-  matchUrl: http://localhost:50500/match-user
-EOF
-    ./bin/verify-matching-service-test-tool
+    ./bin/verify-matching-service-test-tool -e ../../verify-local-matching-service-example/examples -c ../../verify-local-matching-service-example/verify-service-test-tool.yml
 
 popd

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -e
 
-cd "$(dirname "$0")"
-./gradlew clean test intTest
+shutdown="$(realpath shutdown.sh)"
+trap "sh $shutdown" EXIT
 
+cd "$(dirname $0)"
+./gradlew clean test intTest 
+
+./startup.sh
+
+pushd ../verify-matching-service-adapter/verify-matching-service-test-tool >/dev/null
+  ../gradlew clean installDist
+  ./build/install/verify-matching-service-test-tool/bin/verify-matching-service-test-tool -e ../../verify-local-matching-service-example/examples -c ../../verify-local-matching-service-example/verify-matching-service-test-tool.yml
+popd >/dev/null

--- a/startup.sh
+++ b/startup.sh
@@ -1,6 +1,5 @@
 #!/bin/bash -eux
 
-
 docker run --name postgres_for_matching_service -d -p 5432:5432 postgres
 
 # wait for the database to come up
@@ -14,5 +13,5 @@ done
 set -e
 
 # Start example local matching service with database migration
-
+./gradlew clean installDist
 DB_URI="jdbc:postgresql://localhost:5432/postgres?user=postgres" ./build/install/verify-local-matching-service-example/bin/verify-local-matching-service-example &

--- a/verify-matching-service-test-tool.yml
+++ b/verify-matching-service-test-tool.yml
@@ -1,0 +1,3 @@
+localMatchingService:
+  matchUrl: http://localhost:50500/match-user
+


### PR DESCRIPTION
Added a pre-commit to do the same steps as jenkins (start up app,
run DB migrations, test using matching-service-test-tool)
Add test-tool yml file to repo and update scripts to point at
that instead of using heredoc
Add command line flag to test tool instead of cp-ing exmaple files

Authors: @andy-paine