### PR TITLE
Test build with openjdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM govukverify/java8:latest
+FROM govukverify/java8:PR-5.6
 # Be careful not to couple this file with the base image
 # in case of upstream changes - in fact, you should prefer not to 
 # edit this dockerfile if possible.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM govukverify/java8:latest
+# Be careful not to couple this file with the base image
+# in case of upstream changes - in fact, you should prefer not to 
+# edit this dockerfile if possible.

--- a/build.jenkins
+++ b/build.jenkins
@@ -1,0 +1,28 @@
+pipeline {
+  agent none
+  stages {
+
+    stage('Build') {
+      agent {
+        dockerfile {
+         additionalBuildArgs "--pull"
+        }
+      }
+      steps {
+        sh './gradlew build'
+      }
+    }
+
+    stage('Tests') {
+      agent {
+        dockerfile {
+          additionalBuildArgs "--pull"
+        }
+      }
+      steps {
+        sh 'echo "Running unit tests and integration tests"'
+        sh './gradlew test intTest'
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Do not merge - this branch is for testing OpenJDK only**

To avoid the licencing issues around distributing Oracle's code, we're
moving to building our projects using OpenJDK. In order to test that
this works for this project, we are first changing its Dockerfile to
pull FROM our initial openjdk-based version of our java8 Docker image.

Authors: **@roryirvine**