### PR TITLE
wMGvt2dj: Set up LMS for VSP CI pipeline

### DIFF
--- a/ci/integration-manifest.yml
+++ b/ci/integration-manifest.yml
@@ -1,0 +1,11 @@
+applications:
+  - name: ((app))
+    memory: 1G
+    command: (cd local-matching-service && bin/local-matching-service server verify-local-matching-service-example.yml)
+    routes:
+      - route: ((app)).apps.internal
+        services:
+          - ((app))-db
+        buildpack: java_buildpack
+        env:
+          JAVA_HOME: "../.java-buildpack/open_jdk_jre"

--- a/src/main/java/uk/gov/ida/verifylocalmatchingserviceexample/contracts/AddressDto.java
+++ b/src/main/java/uk/gov/ida/verifylocalmatchingserviceexample/contracts/AddressDto.java
@@ -13,7 +13,6 @@ public class AddressDto {
     @NotNull
     private Boolean verified;
     @JsonProperty
-    @NotNull
     private DateTime fromDate;
     @JsonProperty
     private DateTime toDate;

--- a/src/test/java/uk/gov/ida/verifylocalmatchingserviceexample/contracts/AddressDtoTest.java
+++ b/src/test/java/uk/gov/ida/verifylocalmatchingserviceexample/contracts/AddressDtoTest.java
@@ -33,18 +33,6 @@ public class AddressDtoTest {
     }
 
     @Test
-    public void shouldReturnConstraintViolationWhenFromDateIsNull() {
-        AddressDto addressDto = new AddressDtoBuilder().withFromDate(null).build();
-
-        Set<ConstraintViolation<AddressDto>> constraintViolations = validator.validate(addressDto);
-
-        assertEquals(1, constraintViolations.size());
-        ConstraintViolation<AddressDto> violation = constraintViolations.iterator().next();
-        assertEquals("may not be null", violation.getMessage());
-        assertEquals("fromDate", violation.getPropertyPath().toString());
-    }
-
-    @Test
     public void shouldReturnConstraintViolationWhenVerificationIsNull() {
         AddressDto addressDto = new AddressDtoBuilder().withVerified(null).build();
 


### PR DESCRIPTION
2 changes:

wMGvt2Dj: relax validation of fromDate

Stub IDP is not sending fromDates on its addresses which is causing the
LMS to not accept the matching request. This isn't ideal, but we need to
get the VSP end-to-end tests to work so I'm disabling the notNull
 constraint.

wMGvt2Dj: adding a manfiest for LMS in the VSP's ci pipeline
