### PR TITLE
Add build badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Example local matching service for GOV.UK Verify
 
+[![Build Status](https://travis-ci.org/alphagov/verify-local-matching-service-example.svg?branch=master)](https://travis-ci.org/alphagov/verify-local-matching-service-example)
+
 This is an example local matching service built by the GOV.UK Verify team to demonstrate how a local matching service works and help services building their own. Every government service connecting to Verify must build a local matching service.
 
 :warning: _This is an example implementation and is not production-ready._ :warning:


### PR DESCRIPTION
Now that we're successfully building against Java 8 and Java 11, add the badge to the README.