### PR TITLE
HUB-911: Pull from maven central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,9 +8,7 @@ sourceCompatibility = 1.8
 repositories {
     if (System.getenv('VERIFY_USE_PUBLIC_BINARIES') == 'true') {
         logger.warn('Production builds MUST NOT be built with public binaries.\nUse artifactory/allowed-repos for production builds.\n\n')
-        maven { url 'https://dl.bintray.com/alphagov/maven-test' }
-        maven { url 'https://build.shibboleth.net/nexus/content/repositories/releases' }
-        jcenter()
+        mavenCentral()
     }
     else {
         maven { url 'https://gds.jfrog.io/artifactory/allowed-repos' }


### PR DESCRIPTION
Bintray and jcenter are going away - we need to pull from maven central
instead. We've started publishing our libs there. Although this project
doesn't actually use any so it's not a big issue.