### PR TITLE
Update README.md to mark repo as archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 [![Build Status](https://travis-ci.org/alphagov/verify-local-matching-service-example.svg?branch=master)](https://travis-ci.org/alphagov/verify-local-matching-service-example)
 
+>**GOV.UK Verify has closed**
+>
+>This repository is out of date and has been archived
+
+
 This is an example local matching service built by the GOV.UK Verify team to demonstrate how a local matching service works and help services building their own. Every government service connecting to Verify must build a local matching service.
 
 :warning: _This is an example implementation and is not production-ready._ :warning:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Example local matching service for GOV.UK Verify
 
-[![Build Status](https://travis-ci.org/alphagov/verify-local-matching-service-example.svg?branch=master)](https://travis-ci.org/alphagov/verify-local-matching-service-example)
-
 >**GOV.UK Verify has closed**
 >
 >This repository is out of date and has been archived


### PR DESCRIPTION
As agreed in [verify-architecture ADR 0039](https://github.com/alphagov/verify-architecture/blob/master/adr/0039-use-prs-before-archiving-repos.md), a PR must be approved by all engineers on the team before being archived.

Approving this PR indicates approval for this repo to be archived.